### PR TITLE
Updating mq-scss and font-face-generator tags

### DIFF
--- a/sassisfaction.json
+++ b/sassisfaction.json
@@ -466,6 +466,6 @@
          "name": "font-face-generator",
          "url": "https://github.com/Dan503/font-face-generator",
          "description": "An @font-face code generator for SCSS.",
-         "tags": ["generator", "@font-face"]
+         "tags": ["mixin", "@font-face"]
       }
    ]

--- a/sassisfaction.json
+++ b/sassisfaction.json
@@ -460,7 +460,7 @@
          "name": "mq-scss",
          "url": "https://github.com/Dan503/mq-scss",
          "description": "An extreamly powerful but easy to use Sass media query mixin.",
-         "tags": ["mixins", "media query"]
+         "tags": ["mixin", "media queries", "responsive", "breakpoints"]
       },
       {
          "name": "font-face-generator",


### PR DESCRIPTION
## Updating font-face-generator tags

I just updated the code for the `font-face-generator` npm module. It is now able to be used as a mixin so I'm swapping out the `generator` tag for the `mixin` tag.

## Updating mq-scss tags

I'm making the mq-scss tags match up with more of the other media query mixins on the site to improve discoverability.
